### PR TITLE
Fix Finland and Norway buttons not appearing correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,6 +83,7 @@ dist
 # IDE / Editor
 .idea
 .editorconfig
+.vscode
 
 # Service worker
 sw.*

--- a/assets/style/app.scss
+++ b/assets/style/app.scss
@@ -84,6 +84,12 @@
         }
     }
 
+    @media (max-width: 375px) {
+        .country-btn {
+            width: 80px;
+        }
+    }
+
     .v-snack__content{
         a {
             color: white;

--- a/pages/meetup-groups/index.vue
+++ b/pages/meetup-groups/index.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container grid-list-lg fluid>
-    <v-layout row fill-height class="pt-5 pb-5">
-      <v-flex xs7>
+    <v-layout row fill-height class="pt-5 pb-5 d-flex flex-wrap flex-md-nowrap">
+      <v-flex xs4 class="pt-0">
         <h1>GROUPS</h1>
       </v-flex>
-      <v-flex xs5 class="d-flex justify-end justify-space-between">
-        <div class="d-none d-sm-flex">
+      <v-flex xs8 class="d-flex justify-end">
+        <div class="d-none d-lg-flex">
           <template v-for="(country, index) in countries">
-            <v-btn v-if="index==0" outlined rounded :selected="country === selectedCountry" class="country-btn country-btn--all text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
-            <v-btn v-else outlined rounded :selected="country === selectedCountry" class="country-btn text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-if="index==0" outlined rounded :selected="country === selectedCountry" class="country-btn country-btn--all text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-else outlined rounded :selected="country === selectedCountry" class="country-btn text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
           </template>
         </div>
-        <div class="d-flex d-sm-none">
+        <div class="d-flex d-lg-none">
           <v-menu offset-y transition="scroll-y-transition">
             <template v-slot:activator="{ on }">
-              <v-btn outlined rounded class="country-btn text-capitalize" v-on="on">Filter</v-btn>
+              <v-btn outlined rounded class="country-btn text-capitalize mt-1" v-on="on">Filter</v-btn>
             </template>
             <v-list text>
               <template v-for="country in countries">

--- a/pages/members/index.vue
+++ b/pages/members/index.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container v-if="membersByCountry" grid-list-lg fluid>
-    <v-layout row fill-height class="pt-5 pb-5">
-      <v-flex xs7>
+    <v-layout row fill-height class="pt-5 pb-5 d-flex flex-wrap flex-md-nowrap">
+      <v-flex xs4 class="pt-0">
         <h1>MEMBERS</h1>
       </v-flex>
-      <v-flex xs5 class="d-flex justify-end justify-space-between">
-        <div class="d-none d-sm-flex">
+      <v-flex xs8 class="d-flex justify-end">
+        <div class="d-none d-lg-flex">
           <template v-for="(country, index) in countries">
-            <v-btn v-if="index==0" outlined rounded :selected="country === selectedCountry" class="country-btn country-btn--all text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
-            <v-btn v-else outlined rounded :selected="country === selectedCountry" class="country-btn text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-if="index==0" outlined rounded :selected="country === selectedCountry" class="country-btn country-btn--all text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-else outlined rounded :selected="country === selectedCountry" class="country-btn text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
           </template>
         </div>
-        <div class="d-flex d-sm-none">
+        <div class="d-flex d-lg-none">
           <v-menu offset-y transition="scroll-y-transition">
             <template v-slot:activator="{ on }">
-              <v-btn outlined rounded class="country-btn text-capitalize" v-on="on">Filter</v-btn>
+              <v-btn outlined rounded class="country-btn text-capitalize mt-1" v-on="on">Filter</v-btn>
             </template>
             <v-list text>
               <template v-for="country in countries">

--- a/pages/speakers/index.vue
+++ b/pages/speakers/index.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container grid-list-lg fluid>
-    <v-layout row fill-height class="pt-5 pb-5">
-      <v-flex xs7>
+    <v-layout row fill-height class="pt-5 pb-5 d-flex flex-wrap flex-md-nowrap">
+      <v-flex xs4 class="pt-0">
         <h1>SPEAKERS</h1>
       </v-flex>
-      <v-flex xs5 class="d-flex justify-end justify-space-between">
-        <div class="d-none d-sm-flex">
+      <v-flex xs8 class="d-flex justify-end">
+        <div class="d-none d-lg-flex">
           <template v-for="(country, index) in countries">
-            <v-btn v-if="index==0" :selected="country === selectedCountry" outlined rounded class="country-btn country-btn--all text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
-            <v-btn v-else :selected="country === selectedCountry" outlined rounded class="country-btn text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-if="index==0" outlined rounded :selected="country === selectedCountry" class="country-btn country-btn--all text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-else outlined rounded :selected="country === selectedCountry" class="country-btn text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
           </template>
         </div>
-        <div class="d-flex d-sm-none">
+        <div class="d-flex d-lg-none">
           <v-menu offset-y transition="scroll-y-transition">
             <template v-slot:activator="{ on }">
-              <v-btn outlined rounded class="country-btn text-capitalize" v-on="on">Filter</v-btn>
+              <v-btn outlined rounded class="country-btn text-capitalize mt-1" v-on="on">Filter</v-btn>
             </template>
             <v-list text>
               <template v-for="country in countries">

--- a/pages/sponsors/index.vue
+++ b/pages/sponsors/index.vue
@@ -1,20 +1,20 @@
 <template>
   <v-container grid-list-lg fluid>
-    <v-layout row fill-height class="pt-5 pb-5">
-      <v-flex xs7>
+    <v-layout row fill-height class="pt-5 pb-5 d-flex flex-wrap flex-md-nowrap">
+      <v-flex xs4 class="pt-0">
         <h1>SPONSORS</h1>
       </v-flex>
-      <v-flex xs5 class="d-flex justify-end justify-space-between">
-        <div class="d-none d-sm-flex">
+      <v-flex xs8 class="d-flex justify-end">
+        <div class="d-none d-lg-flex">
           <template v-for="(country, index) in countries">
-            <v-btn v-if="index==0" :selected="country === selectedCountry" outlined rounded class="country-btn country-btn--all text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
-            <v-btn v-else outlined :selected="country === selectedCountry" rounded class="country-btn text-capitalize mr-2" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-if="index==0" outlined rounded :selected="country === selectedCountry" class="country-btn country-btn--all text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
+            <v-btn v-else outlined rounded :selected="country === selectedCountry" class="country-btn text-capitalize mr-2 mt-1" v-bind:key="country" @click="setSelectedCountry(country)">{{country}}</v-btn>
           </template>
         </div>
-        <div class="d-flex d-sm-none">
+        <div class="d-flex d-lg-none">
           <v-menu offset-y transition="scroll-y-transition">
             <template v-slot:activator="{ on }">
-              <v-btn outlined rounded class="country-btn text-capitalize" v-on="on">Filter</v-btn>
+              <v-btn outlined rounded class="country-btn text-capitalize mt-1" v-on="on">Filter</v-btn>
             </template>
             <v-list text>
               <template v-for="country in countries">


### PR DESCRIPTION
I made som extra space for the filter buttons on the meetups page. I also changed the size of the filter buttons for smaller screens, in order to have it not overlap with the heading.

Fixes #22 