### PR TITLE
Change Copenhagen chapter from Bevy to Meetup

### DIFF
--- a/app/groups/[slug]/page.tsx
+++ b/app/groups/[slug]/page.tsx
@@ -78,7 +78,7 @@ export default async function GroupPage({ params }: PageProps) {
               rel="noopener noreferrer"
               className="inline-flex items-center gap-1 px-3 py-1 rounded-full text-sm bg-white/10 text-gray-300 hover:bg-white/20 transition-colors"
             >
-              View on Bevy
+              View on {group.platform === "meetup" ? "Meetup" : "Bevy"}
               <svg className="w-3.5 h-3.5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
                 <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14" />
               </svg>

--- a/data/groups/copenhagen.yaml
+++ b/data/groups/copenhagen.yaml
@@ -3,6 +3,6 @@ city: Copenhagen
 country: Denmark
 latitude: 55.6761
 longitude: 12.5683
-platform: bevy
-platform_url: https://community.cncf.io/cloud-native-copenhagen/
+platform: meetup
+platform_url: https://www.meetup.com/cloud-native-copenhagen/?eventOrigin=home_groups_you_organize
 member_count: 1500

--- a/lib/groups-data.json
+++ b/lib/groups-data.json
@@ -153,8 +153,8 @@
     "country": "Denmark",
     "latitude": 55.6761,
     "longitude": 12.5683,
-    "platform": "bevy",
-    "platform_url": "https://community.cncf.io/cloud-native-copenhagen/",
+    "platform": "meetup",
+    "platform_url": "https://www.meetup.com/cloud-native-copenhagen/?eventOrigin=home_groups_you_organize",
     "member_count": 1500
   },
   {


### PR DESCRIPTION
## Summary
- Copenhagen uses Meetup, not Bevy. Updated platform and URL in `data/groups/copenhagen.yaml` and `lib/groups-data.json`
- Made the "View on Bevy/Meetup" button text dynamic based on the group's platform field in the group detail page

## Test plan
- [x] `npm run build` passes successfully
- [ ] Verify Copenhagen group page shows "View on Meetup" button linking to the Meetup URL
- [ ] Verify other groups still show "View on Bevy"

🤖 Generated with [Claude Code](https://claude.com/claude-code)